### PR TITLE
fix pip install for CBC

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,7 @@ then:
 
 .. code-block:: bash
 
-    $ pip install pygamma-agreement[CBC]
+    $ pip install "pygamma-agreement[CBC]"
 
 .. warning::
 


### PR DESCRIPTION
pygamma-agreement[CBC] needs to be enclosed in quotes