### PR TITLE
fixed a bug when importing using pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,6 @@ pygamma-agreement = "pygamma_agreement.cli_apps:pygamma_cmd"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["pygamma-agreement*"]
+include = ["pygamma_agreement*"]
 exclude = ["docs*", "tests*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,6 @@ pygamma-agreement = "pygamma_agreement.cli_apps:pygamma_cmd"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["adfluo*"]
+include = ["pygamma-agreement*"]
 exclude = ["docs*", "tests*"]
 


### PR DESCRIPTION
Fixed the issue that the package couldn't be imported after installing with pip (thanks, @fleonce!). See [the corresponding issue](https://github.com/bootphon/pygamma-agreement/issues/45)! 